### PR TITLE
Fix deprecated call to strtolower with null parameter

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -462,12 +462,12 @@ class Uri implements UriInterface
 
     protected function normalizeSchemeCase()
     {
-        $this->scheme = strtolower($this->scheme);
+        $this->scheme = strtolower($this->scheme === null ? "" : $this->scheme);
     }
 
     protected function normalizeHostCase()
     {
-        $this->host = strtolower($this->host);
+        $this->host = strtolower($this->host === null ? "" : $this->host);
     }
 
     protected function normalizePort()


### PR DESCRIPTION
In newer versions of PHP, calling `strtolower()` with a null parameter is deprecated.

This simply checks for null values and replaces them with an empty string in order to re-create the previous behaviour of `strtolower()`.